### PR TITLE
🔧(project) activate renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["github>openfun/renovate-configuration"],
+  "commitMessagePrefix": "⬆️(project)",
+  "commitMessageAction": "upgrade",
+  "commitBodyTable": true
+}


### PR DESCRIPTION
## Purpose

We use renovate to keep project dependencies up-to-date.

## Proposal

- [x] Add standard configuration file for all our projects.
