### PR TITLE
🐛(obf) remove json deserialization of empty lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Remove deserialization of empty JSON lines
+
 ## [0.2.0] - 2023-08-07
 
 ### Changed

--- a/src/obc/providers/obf.py
+++ b/src/obc/providers/obf.py
@@ -130,7 +130,7 @@ class OBFAPIClient(requests.Session):
         When multiple objects are returned by the API, they are streamed as
         JSON lines instead of a JSON list, leading the response.json() method
         to fail as it is expected a valid JSON list instead. We mitigate this
-        issue by forcing JSON serialization of each item in the response.
+        issue by forcing JSON serialization of each non-empty item in the response.
         """
         try:
             json_response = response.json()
@@ -140,6 +140,8 @@ class OBFAPIClient(requests.Session):
                 yield json_response
         except requests.JSONDecodeError:
             for line in response.iter_lines():
+                if not line:
+                    continue
                 yield json.loads(line)
 
     # pylint: disable=arguments-differ

--- a/tests/providers/test_obf.py
+++ b/tests/providers/test_obf.py
@@ -243,6 +243,10 @@ def test_iter_json():
         {"id": "3"},
     ]
 
+    response = requests.Response()
+    response._content = b'{"id": "1"}\n\n{"id": "3"}\n'
+    assert list(OBFAPIClient.iter_json(response)) == [{"id": "1"}, {"id": "3"}]
+
 
 def test_badge_query_params():
     """Test the BadgeQuery model params method."""


### PR DESCRIPTION
When using the `read` method to get multiple objects (e.g. to get all badges),
they are streamed as JSON lines but some lines can be sent empty (probably a
bug on the OBF side) and method `json.loads` fail. Mitigating this by not
deserializing empty lines.

