### PR TITLE
✨(obf) add the ability to read issue events and assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Return a `BadgeIssue` instance in the `issue` method [BC]
+- Add a `badges` attribute to OBF provider for badges methods [BC]
+- Add `events` and `assertions` attributes to OBF provider
+- Add `read` method for `events` and `assertions` attributes of OBF provider 
+
 ## [0.2.1] - 2023-08-23
 
 ### Changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ skip_glob=venv
 profile=black
 
 [tool:pytest]
-addopts = -v --cov-report term-missing --cov-config=.coveragerc --cov=src/obc
+addopts = -v --cov-report term-missing --cov-config=.coveragerc --cov=obc
 python_files =
     test_*.py
     tests.py

--- a/src/obc/providers/base.py
+++ b/src/obc/providers/base.py
@@ -3,15 +3,24 @@
 from abc import ABC, abstractmethod
 
 
-class BaseProvider(ABC):
-    """Base badge provider class."""
-
-    code: str = "BPC"
-    name: str = "Base provider"
+class BaseAssertion(ABC):
+    """Base assertion class."""
 
     @abstractmethod
-    def __init__(self, *args, **kwargs):
-        """Initialize the API client."""
+    def __init__(self, api_client):
+        """Initialize the assertion class."""
+
+    @abstractmethod
+    def read(self, assertion, query=None):
+        """Read an assertion."""
+
+
+class BaseBadge(ABC):
+    """Base badge class."""
+
+    @abstractmethod
+    def __init__(self, api_client):
+        """Initialize the badge class."""
 
     @abstractmethod
     def create(self, badge):
@@ -36,3 +45,14 @@ class BaseProvider(ABC):
     @abstractmethod
     def revoke(self, revokation):
         """Revoke one or more badges."""
+
+
+class BaseProvider(ABC):
+    """Base provider class."""
+
+    code: str = "BPC"
+    name: str = "Base provider"
+
+    @abstractmethod
+    def __init__(self, *args, **kwargs):
+        """Initialize the API client, the badge and the assertion classes."""

--- a/tests/providers/test_obf.py
+++ b/tests/providers/test_obf.py
@@ -1,18 +1,23 @@
-"""Test suite for the OBF badge provider."""
+"""Test suite for the OBF badge provider."""  # pylint: disable = too-many-lines
 
+import logging
 import re
 
 import pytest
 import requests
 import responses
+from pydantic import ValidationError
 
 from obc.exceptions import AuthenticationError, BadgeProviderError
 from obc.providers.obf import (
     OBF,
+    AssertionQuery,
     Badge,
+    BadgeAssertion,
     BadgeIssue,
     BadgeQuery,
     BadgeRevokation,
+    IssueQuery,
     OAuth2AccessToken,
     OBFAPIClient,
 )
@@ -264,6 +269,50 @@ def test_badge_query_params():
     assert params.get("meta") is None
 
 
+def test_badge_check_id():
+    """Test the Badge check_id method."""
+
+    items = {
+        "name": "toto",
+        "description": "lorem ipsum",
+        "is_created": True,
+        "id": None,
+    }
+    with pytest.raises(
+        ValidationError,
+        match="Created badges should have an `id` field.",
+    ):
+        Badge(**items)
+
+
+def test_badgeissue_check_ids():
+    """Test the BadgeIssue check_ids method."""
+
+    items = {
+        "recipient": ["toto@bar.com"],
+        "is_created": True,
+        "id": None,
+        "badge_id": "1234",
+    }
+    with pytest.raises(
+        ValidationError,
+        match="Badge issues should have both an `id` and `badge_id` field.",
+    ):
+        BadgeIssue(**items)
+
+    items = {
+        "recipient": ["toto@bar.com"],
+        "is_created": True,
+        "id": "1234",
+        "badge_id": None,
+    }
+    with pytest.raises(
+        ValidationError,
+        match="Badge issues should have both an `id` and `badge_id` field.",
+    ):
+        BadgeIssue(**items)
+
+
 def test_provider_init(mocked_responses):
     """Test the OBF class instantiation."""
 
@@ -308,10 +357,10 @@ def test_provider_raise_for_status(mocked_responses):
             "https://openbadgefactory.com/v1/badge/real_client"
         ),
     ):
-        next(obf.read())
+        next(obf.badges.read())
 
 
-def test_provider_read_all(mocked_responses):
+def test_provider_badge_read_all(mocked_responses):
     """Test the OBF read method without argument."""
 
     mocked_responses.post(
@@ -329,7 +378,7 @@ def test_provider_read_all(mocked_responses):
         json=[],
         status=200,
     )
-    assert len(list(obf.read())) == 0
+    assert len(list(obf.badges.read())) == 0
 
     mocked_responses.add(
         responses.GET,
@@ -341,7 +390,7 @@ def test_provider_read_all(mocked_responses):
         ],
         status=200,
     )
-    badges = list(obf.read())
+    badges = list(obf.badges.read())
     for badge in badges:
         assert isinstance(badge, Badge)
     assert badges[0].id == "1"
@@ -355,7 +404,7 @@ def test_provider_read_all(mocked_responses):
     assert badges[2].description == "lorem ipsum"
 
 
-def test_provider_read_one(mocked_responses):
+def test_provider_badge_read_one(mocked_responses):
     """Test the OBF read method with a given badge argument."""
 
     mocked_responses.post(
@@ -381,7 +430,7 @@ def test_provider_read_one(mocked_responses):
         status=200,
     )
     target_badge = Badge(id="1", name="foo", description="lorem ipsum")
-    badge = next(obf.read(badge=target_badge))
+    badge = next(obf.badges.read(badge=target_badge))
     assert badge.id == "1"
     assert "life" in badge.metadata
     assert badge.metadata.get("life") == 42
@@ -391,10 +440,10 @@ def test_provider_read_one(mocked_responses):
         BadgeProviderError,
         match="the ID field is required",
     ):
-        next(obf.read(badge=target_badge))
+        next(obf.badges.read(badge=target_badge))
 
 
-def test_provider_read_selected(mocked_responses):
+def test_provider_badge_read_selected(mocked_responses):
     """Test the OBF read method with a badge query."""
 
     mocked_responses.post(
@@ -413,7 +462,7 @@ def test_provider_read_selected(mocked_responses):
         status=200,
     )
     query = BadgeQuery(draft=0)
-    assert len(list(obf.read(query=query))) == 0
+    assert len(list(obf.badges.read(query=query))) == 0
 
     mocked_responses.add(
         responses.GET,
@@ -426,10 +475,49 @@ def test_provider_read_selected(mocked_responses):
         status=200,
     )
     query = BadgeQuery(query="lorem ipsum")
-    assert len(list(obf.read(query=query))) == 3
+    assert len(list(obf.badges.read(query=query))) == 3
 
 
-def test_provider_create(mocked_responses):
+def test_provider_badge_read_with_validationerror(mocked_responses, caplog):
+    """Test the OBF read method with a validation error."""
+
+    mocked_responses.post(
+        "https://openbadgefactory.com/v1/client/oauth2/token",
+        json={
+            "access_token": "accesstoken123",
+        },
+        status=200,
+    )
+    obf = OBF(client_id="real_client", client_secret="super_duper")
+
+    mocked_responses.add(
+        responses.GET,
+        "https://openbadgefactory.com/v1/badge/real_client",
+        json=[],
+        status=200,
+    )
+    query = BadgeQuery(draft=0)
+    assert len(list(obf.badges.read(query=query))) == 0
+
+    mocked_responses.add(
+        responses.GET,
+        "https://openbadgefactory.com/v1/badge/real_client",
+        json=[
+            {"id": "1", "name": 1, "description": "lorem ipsum"},
+            {"id": "2", "name": "bar", "description": "lorem ipsum"},
+        ],
+        status=200,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert len(list(obf.badges.read())) == 1
+
+    assert ("obc.providers.obf", logging.WARNING) in [
+        (class_, level) for (class_, level, _) in caplog.record_tuples
+    ]
+
+
+def test_provider_badge_create(mocked_responses):
     """Test the OBF create method with a given badge argument."""
 
     mocked_responses.post(
@@ -457,7 +545,7 @@ def test_provider_create(mocked_responses):
         json=mocked.model_dump(),
         status=200,
     )
-    created = obf.create(badge=submitted)
+    created = obf.badges.create(badge=submitted)
 
     assert created.name == "foo"
     assert created.description == "lorem ipsum"
@@ -470,10 +558,10 @@ def test_provider_create(mocked_responses):
         status=500,
     )
     with pytest.raises(BadgeProviderError, match="Cannot create badge"):
-        obf.create(badge=submitted)
+        obf.badges.create(badge=submitted)
 
 
-def test_provider_update(mocked_responses):
+def test_provider_badge_update(mocked_responses):
     """Test the OBF update method with a given badge argument."""
 
     mocked_responses.post(
@@ -488,7 +576,7 @@ def test_provider_update(mocked_responses):
     with pytest.raises(
         BadgeProviderError, match="We expect an existing badge instance"
     ):
-        obf.update(Badge(name="foo", description="lorem ipsum"))
+        obf.badges.update(Badge(name="foo", description="lorem ipsum"))
 
     badge = Badge(id="abcd1234", name="foo", description="lorem ipsum")
     mocked_responses.add(
@@ -496,7 +584,7 @@ def test_provider_update(mocked_responses):
         "https://openbadgefactory.com/v1/badge/real_client/abcd1234",
         status=204,
     )
-    updated = obf.update(badge)
+    updated = obf.badges.update(badge)
     assert updated == badge
 
     # An error occurred while updating the badge
@@ -508,10 +596,10 @@ def test_provider_update(mocked_responses):
     with pytest.raises(
         BadgeProviderError, match="Cannot update badge with ID: abcd1234"
     ):
-        obf.update(badge=badge)
+        obf.badges.update(badge=badge)
 
 
-def test_provider_delete_one(mocked_responses):
+def test_provider_badge_delete_one(mocked_responses):
     """Test the OBF delete method with a given badge argument."""
 
     mocked_responses.post(
@@ -526,7 +614,7 @@ def test_provider_delete_one(mocked_responses):
     with pytest.raises(
         BadgeProviderError, match="We expect an existing badge instance"
     ):
-        obf.delete(Badge(name="foo", description="lorem ipsum"))
+        obf.badges.delete(Badge(name="foo", description="lorem ipsum"))
 
     badge = Badge(id="abcd1234", name="foo", description="lorem ipsum")
     mocked_responses.add(
@@ -534,7 +622,7 @@ def test_provider_delete_one(mocked_responses):
         "https://openbadgefactory.com/v1/badge/real_client/abcd1234",
         status=204,
     )
-    assert obf.delete(badge) is None
+    assert obf.badges.delete(badge) is None
 
     # An error occurred while deleting the badge
     mocked_responses.add(
@@ -545,10 +633,10 @@ def test_provider_delete_one(mocked_responses):
     with pytest.raises(
         BadgeProviderError, match="Cannot delete badge with ID: abcd1234"
     ):
-        obf.delete(badge=badge)
+        obf.badges.delete(badge=badge)
 
 
-def test_provider_delete_all(mocked_responses):
+def test_provider_badge_delete_all(mocked_responses):
     """Test the OBF delete method without badge argument (delete all badges)."""
 
     mocked_responses.post(
@@ -565,7 +653,7 @@ def test_provider_delete_all(mocked_responses):
         "https://openbadgefactory.com/v1/badge/real_client",
         status=204,
     )
-    assert obf.delete() is None
+    assert obf.badges.delete() is None
 
     # An error occurred while updating the badge
     mocked_responses.add(
@@ -577,10 +665,10 @@ def test_provider_delete_all(mocked_responses):
         BadgeProviderError,
         match="Cannot delete badges for client with ID: real_client",
     ):
-        obf.delete()
+        obf.badges.delete()
 
 
-def test_provider_issue_non_existing(mocked_responses):
+def test_provider_badge_issue_non_existing(mocked_responses):
     """Trying to issue a badge for a non-existing instance should fail."""
 
     mocked_responses.post(
@@ -602,10 +690,10 @@ def test_provider_issue_non_existing(mocked_responses):
         BadgeProviderError,
         match="We expect an existing badge instance",
     ):
-        obf.issue(badge, issue)
+        obf.badges.issue(badge, issue)
 
 
-def test_provider_issue_draft(mocked_responses):
+def test_provider_badge_issue_draft(mocked_responses):
     """Trying to issue a badge for a draft instance should fail."""
 
     mocked_responses.post(
@@ -627,10 +715,10 @@ def test_provider_issue_draft(mocked_responses):
         BadgeProviderError,
         match="You cannot issue a badge with a draft status",
     ):
-        obf.issue(badge, issue)
+        obf.badges.issue(badge, issue)
 
 
-def test_provider_issue_success(mocked_responses):
+def test_provider_badge_issue_success(mocked_responses):
     """Test the OBF issue method."""
 
     mocked_responses.post(
@@ -642,36 +730,49 @@ def test_provider_issue_success(mocked_responses):
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    badge = Badge(id="abcd1234", name="test", description="lorem ipsum", draft=False)
-    issue = BadgeIssue(
+    badge = Badge(id="badgeId1234", name="test", description="lorem ipsum", draft=False)
+    submitted_issue = BadgeIssue(
         recipient=[
             "foo@example.org",
-        ]
+        ],
+        email_subject="Subject of the email",
     )
-
+    mocked = submitted_issue.model_copy()
+    mocked.id = "issueId1234"
+    mocked.badge_id = "badgeId1234"
+    del mocked.is_created
     mocked_responses.add(
         responses.POST,
-        "https://openbadgefactory.com/v1/badge/real_client/abcd1234",
+        "https://openbadgefactory.com/v1/badge/real_client/badgeId1234",
         status=201,
-        headers={"Location": "/v1/event/real_client/foo_event"},
+        headers={"Location": "/v1/event/real_client/issueId1234"},
     )
-    event_url, event_id = obf.issue(badge, issue)
-    assert event_url == "/v1/event/real_client/foo_event"
-    assert event_id == "foo_event"
+    mocked_responses.add(
+        responses.GET,
+        "https://openbadgefactory.com/v1/event/real_client/issueId1234",
+        json=mocked.model_dump(),
+        status=200,
+    )
+    created_issue = obf.badges.issue(badge, submitted_issue)
+    assert created_issue.email_subject == submitted_issue.email_subject
+    assert created_issue.badge_id == badge.id
+    assert not created_issue.revoked
+    assert created_issue.is_created
+    assert created_issue.id == "issueId1234"
 
     mocked_responses.add(
         responses.POST,
-        "https://openbadgefactory.com/v1/badge/real_client/abcd1234",
+        "https://openbadgefactory.com/v1/badge/real_client/badgeId1234",
         status=500,
     )
     with pytest.raises(
         BadgeProviderError,
-        match="Cannot issue badge with ID: abcd1234",
+        match="Cannot issue badge with ID: badgeId1234",
     ):
-        obf.issue(badge, issue)
+        obf.badges.issue(badge, submitted_issue)
 
 
-def test_provider_revoke(mocked_responses):
+def test_provider_badge_revoke(mocked_responses):
     """Test the OBF revoke method."""
 
     mocked_responses.post(
@@ -694,7 +795,7 @@ def test_provider_revoke(mocked_responses):
         ],
     )
     assert (
-        obf.revoke(
+        obf.badges.revoke(
             BadgeRevokation(
                 event_id="foo_event",
                 recipient=["foo@example.org", "bar@example.org"],
@@ -718,7 +819,7 @@ def test_provider_revoke(mocked_responses):
             )
         ),
     ):
-        obf.revoke(
+        obf.badges.revoke(
             BadgeRevokation(
                 event_id="foo_event",
                 recipient=[
@@ -726,3 +827,374 @@ def test_provider_revoke(mocked_responses):
                 ],
             )
         )
+
+
+def test_provider_event_read_all(mocked_responses):
+    """Test the OBF event read method without argument."""
+
+    mocked_responses.post(
+        "https://openbadgefactory.com/v1/client/oauth2/token",
+        json={
+            "access_token": "accesstoken123",
+        },
+        status=200,
+    )
+    obf = OBF(client_id="real_client", client_secret="super_duper")
+
+    mocked_responses.add(
+        responses.GET,
+        "https://openbadgefactory.com/v1/event/real_client",
+        json=[],
+        status=200,
+    )
+    assert len(list(obf.events.read())) == 0
+
+    mocked_responses.add(
+        responses.GET,
+        "https://openbadgefactory.com/v1/event/real_client",
+        json=[
+            {
+                "id": "1",
+                "badge_id": "1234",
+                "recipient": ["foo@bar.com", "bar@foo.com"],
+                "expires": 1670832081,
+                "issued_on": 1670822080,
+                "revoked": {},
+                "log_entry": {"issuer": "luc"},
+            },
+            {
+                "id": "2",
+                "badge_id": "5678",
+                "recipient": ["toto@bar.com", "tata@foo.com"],
+                "expires": 9876543211,
+                "issued_on": 9876543210,
+                "revoked": {"an_id1234": 9876543212},
+                "log_entry": {"issuer": "anonymous"},
+            },
+        ],
+        status=200,
+    )
+    issues = list(obf.events.read())
+    for issue in issues:
+        assert isinstance(issue, BadgeIssue)
+    assert issues[0].id == "1"
+    assert issues[0].badge_id == "1234"
+    assert issues[0].recipient == ["foo@bar.com", "bar@foo.com"]
+    assert issues[0].expires == 1670832081
+    assert issues[0].issued_on == 1670822080
+    assert issues[0].revoked == {}
+    assert issues[0].log_entry == {"issuer": "luc"}
+    assert issues[0].is_created
+    assert issues[1].id == "2"
+    assert issues[1].badge_id == "5678"
+    assert issues[1].recipient == ["toto@bar.com", "tata@foo.com"]
+    assert issues[1].expires == 9876543211
+    assert issues[1].issued_on == 9876543210
+    assert issues[1].revoked == {"an_id1234": 9876543212}
+    assert issues[1].log_entry == {"issuer": "anonymous"}
+    assert issues[1].is_created
+
+
+def test_provider_event_read_one(mocked_responses):
+    """Test the OBF event read method with a given issue argument."""
+
+    mocked_responses.post(
+        "https://openbadgefactory.com/v1/client/oauth2/token",
+        json={
+            "access_token": "accesstoken123",
+        },
+        status=200,
+    )
+    obf = OBF(client_id="real_client", client_secret="super_duper")
+
+    mocked_responses.add(
+        responses.GET,
+        "https://openbadgefactory.com/v1/event/real_client/1",
+        json={
+            "id": "1",
+            "badge_id": "1234",
+            "recipient": ["foo@bar.com", "bar@foo.com"],
+            "expires": 1670832081,
+            "issued_on": 1670822080,
+            "revoked": {},
+            "log_entry": {"issuer": "luc"},
+        },
+        status=200,
+    )
+    target_issue = BadgeIssue(id="1", recipient=["foo@bar.com"])
+    issue = next(obf.events.read(issue=target_issue))
+    assert issue == BadgeIssue(
+        id="1",
+        badge_id="1234",
+        recipient=["foo@bar.com", "bar@foo.com"],
+        expires=1670832081,
+        issued_on=1670822080,
+        revoked={},
+        log_entry={"issuer": "luc"},
+        is_created=True,
+    )
+
+    target_issue = BadgeIssue(recipient=["foo@bar.com"])
+    with pytest.raises(
+        BadgeProviderError,
+        match="the ID field is required",
+    ):
+        next(obf.events.read(issue=target_issue))
+
+
+def test_provider_event_read_selected(mocked_responses):
+    """Test the OBF event read method with a issue query."""
+
+    mocked_responses.post(
+        "https://openbadgefactory.com/v1/client/oauth2/token",
+        json={
+            "access_token": "accesstoken123",
+        },
+        status=200,
+    )
+    obf = OBF(client_id="real_client", client_secret="super_duper")
+
+    mocked_responses.add(
+        responses.GET,
+        "https://openbadgefactory.com/v1/event/real_client",
+        json=[],
+        status=200,
+    )
+    query = IssueQuery()
+    assert len(list(obf.events.read(query=query))) == 0
+
+    mocked_responses.add(
+        responses.GET,
+        "https://openbadgefactory.com/v1/event/real_client",
+        json=[
+            {
+                "id": "1",
+                "badge_id": "1234",
+                "recipient": ["foo@bar.com", "bar@foo.com"],
+                "expires": 1670832081,
+                "issued_on": 1670822080,
+                "revoked": {},
+                "log_entry": {"issuer": "luc"},
+            },
+            {
+                "id": "2",
+                "badge_id": "1234",
+                "recipient": ["toto@bar.com", "tata@foo.com"],
+                "expires": 1670832083,
+                "issued_on": 1670822082,
+                "revoked": {},
+                "log_entry": {"issuer": "toto"},
+            },
+            {
+                "id": "3",
+                "badge_id": "2345",
+                "recipient": ["toto@bar.com", "tata@foo.com"],
+                "expires": 1670832085,
+                "issued_on": 1670822084,
+                "revoked": {},
+                "log_entry": {"issuer": "tata"},
+            },
+        ],
+        status=200,
+    )
+    query = IssueQuery(recipient=["toto@bar.com", "tata@foo.com"])
+    assert len(list(obf.events.read(query=query))) == 3
+
+
+def test_provider_event_read_with_validationerror(mocked_responses, caplog):
+    """Test the OBF event read method with a validation error."""
+
+    mocked_responses.post(
+        "https://openbadgefactory.com/v1/client/oauth2/token",
+        json={
+            "access_token": "accesstoken123",
+        },
+        status=200,
+    )
+    obf = OBF(client_id="real_client", client_secret="super_duper")
+
+    mocked_responses.add(
+        responses.GET,
+        "https://openbadgefactory.com/v1/event/real_client",
+        json=[
+            {
+                "id": "1",
+                "badge_id": "1234",
+                "recipient": "bad_formatted_list",
+                "expires": 1670832081,
+                "issued_on": 1670822080,
+                "revoked": {},
+                "log_entry": {"issuer": "luc"},
+            },
+            {
+                "id": "2",
+                "badge_id": "1234",
+                "recipient": ["toto@bar.com", "tata@foo.com"],
+                "expires": 1670832083,
+                "issued_on": 1670822082,
+                "revoked": {},
+                "log_entry": {"issuer": "toto"},
+            },
+        ],
+        status=200,
+    )
+    with caplog.at_level(logging.WARNING):
+        assert len(list(obf.events.read())) == 1
+
+    assert ("obc.providers.obf", logging.WARNING) in [
+        (class_, level) for (class_, level, _) in caplog.record_tuples
+    ]
+
+
+def test_provider_assertion_read_all(mocked_responses):
+    """Test the OBF assertion read method without argument."""
+
+    mocked_responses.post(
+        "https://openbadgefactory.com/v1/client/oauth2/token",
+        json={
+            "access_token": "accesstoken123",
+        },
+        status=200,
+    )
+    obf = OBF(client_id="real_client", client_secret="super_duper")
+
+    mocked_responses.add(
+        responses.GET,
+        "https://openbadgefactory.com/v1/event/real_client/1/assertion",
+        json=[
+            {
+                "id": "1234",
+                "image": "http://obf.com/image",
+                "json": "http://obf.com/json",
+                "pdf": {"default": "http://obf.com/pdf"},
+                "recipient": "toto@bar.com",
+                "status": "accepted",
+            },
+            {
+                "id": "5678",
+                "image": "http://obf.com/image2",
+                "json": "http://obf.com/json2",
+                "pdf": {
+                    "default": "http://obf.com/pdf2",
+                    "fr": "http://obf.com/pdf_fr",
+                },
+                "recipient": "foo@bar.com",
+                "status": "accepted",
+            },
+        ],
+        status=200,
+    )
+    assertion = BadgeAssertion(event_id="1")
+    assertions = list(obf.assertions.read(assertion=assertion))
+    for assertion in assertions:
+        assert isinstance(assertion, BadgeAssertion)
+    assert assertions[0].id == "1234"
+    assert str(assertions[0].image) == "http://obf.com/image"
+    assert str(assertions[0].url) == "http://obf.com/json"
+    assert assertions[0].pdf == {"default": "http://obf.com/pdf"}
+    assert assertions[0].recipient == "toto@bar.com"
+    assert assertions[0].status == "accepted"
+    assert assertions[1].id == "5678"
+    assert str(assertions[1].image) == "http://obf.com/image2"
+    assert str(assertions[1].url) == "http://obf.com/json2"
+    assert assertions[1].pdf == {
+        "default": "http://obf.com/pdf2",
+        "fr": "http://obf.com/pdf_fr",
+    }
+    assert assertions[1].recipient == "foo@bar.com"
+    assert assertions[1].status == "accepted"
+
+
+def test_provider_assertion_read_selected(mocked_responses):
+    """Test the OBF event assertion read method with an assertion query."""
+
+    mocked_responses.post(
+        "https://openbadgefactory.com/v1/client/oauth2/token",
+        json={
+            "access_token": "accesstoken123",
+        },
+        status=200,
+    )
+    obf = OBF(client_id="real_client", client_secret="super_duper")
+
+    mocked_responses.add(
+        responses.GET,
+        "https://openbadgefactory.com/v1/event/real_client/4321/assertion",
+        json=[
+            {
+                "id": "1234",
+                "image": "http://obf.com/image",
+                "json": "http://obf.com/json",
+                "pdf": {"default": "http://obf.com/pdf"},
+                "recipient": "foo@bar.com",
+                "status": "accepted",
+            },
+            {
+                "id": "5678",
+                "image": "http://obf.com/image2",
+                "json": "http://obf.com/json2",
+                "pdf": {
+                    "default": "http://obf.com/pdf2",
+                    "fr": "http://obf.com/pdf_fr",
+                },
+                "recipient": "foo@bar.com",
+                "status": "accepted",
+            },
+        ],
+        status=200,
+    )
+    assertion = BadgeAssertion(event_id="4321")
+    query = AssertionQuery(email=["foo@bar.com"])
+    assert len(list(obf.assertions.read(assertion=assertion, query=query))) == 2
+
+
+def test_provider_assertion_read_with_validationerror(mocked_responses, caplog):
+    """Test the OBF event assertion read method with a validation error."""
+
+    mocked_responses.post(
+        "https://openbadgefactory.com/v1/client/oauth2/token",
+        json={
+            "access_token": "accesstoken123",
+        },
+        status=200,
+    )
+    obf = OBF(client_id="real_client", client_secret="super_duper")
+
+    mocked_responses.add(
+        responses.GET,
+        "https://openbadgefactory.com/v1/event/real_client/4321/assertion",
+        json=[
+            {
+                "id": "1234",
+                "image": "bad_formatted_url",
+                "json": None,
+                "pdf": {},
+                "recipient": None,
+                "status": None,
+            },
+            {
+                "id": "5678",
+                "image": None,
+                "json": None,
+                "pdf": {},
+                "recipient": None,
+                "status": None,
+            },
+        ],
+        status=200,
+    )
+
+    assertion = BadgeAssertion(event_id="4321")
+    with caplog.at_level(logging.WARNING):
+        assert len(list(obf.assertions.read(assertion=assertion))) == 1
+
+    assert ("obc.providers.obf", logging.WARNING) in [
+        (class_, level) for (class_, level, _) in caplog.record_tuples
+    ]
+
+    assertion.event_id = None
+    with pytest.raises(
+        BadgeProviderError,
+        match="We expect an existing issue",
+    ):
+        list(obf.assertions.read(assertion=assertion))


### PR DESCRIPTION
## Purpose
OBC was able to read badges but not issue events nor assertions from OBF.


## Proposal
- Adding the ability to do so with the `OBFEvent.read` and `OBFAssertion.read` methods
- Changing `issue` method to return a `BadgeIssue` instance

