### PR TITLE
♻️(obf) switch obf provider to be async with httpx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Change providers methods to be asynchronous [BC]
 - Return a `BadgeIssue` instance in the `issue` method [BC]
 - Add a `badges` attribute to OBF provider for badges methods [BC]
+- Change from `requests` to `httpx` for API requests
 - Add `events` and `assertions` attributes to OBF provider
 - Add `read` method for `events` and `assertions` attributes of OBF provider 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 include_package_data = True
 install_requires =
     pydantic[email]>=2.0.0
-    requests>=2.0.0
+    httpx>=0.24.1
 package_dir =
     =src
 packages = find:
@@ -42,6 +42,7 @@ dev =
     pylint==2.17.5
     pytest==7.4.1
     pytest-cov==4.1.0
+    pytest-httpx==0.23.1 
     responses==0.23.3
 ci =
     twine==4.0.2

--- a/src/obc/providers/base.py
+++ b/src/obc/providers/base.py
@@ -11,7 +11,7 @@ class BaseAssertion(ABC):
         """Initialize the assertion class."""
 
     @abstractmethod
-    def read(self, assertion, query=None):
+    async def read(self, assertion, query=None):
         """Read an assertion."""
 
 
@@ -23,27 +23,27 @@ class BaseBadge(ABC):
         """Initialize the badge class."""
 
     @abstractmethod
-    def create(self, badge):
+    async def create(self, badge):
         """Create a badge."""
 
     @abstractmethod
-    def read(self, badge=None, query=None):
+    async def read(self, badge=None, query=None):
         """Read a badge."""
 
     @abstractmethod
-    def update(self, badge):
+    async def update(self, badge):
         """Update a badge."""
 
     @abstractmethod
-    def delete(self, badge=None):
+    async def delete(self, badge=None):
         """Delete a badge."""
 
     @abstractmethod
-    def issue(self, badge, issue):
+    async def issue(self, badge, issue):
         """Issue a badge."""
 
     @abstractmethod
-    def revoke(self, revokation):
+    async def revoke(self, revokation):
         """Revoke one or more badges."""
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,4 +2,4 @@
 
 # pylint: disable=unused-import
 
-from .fixtures import mocked_responses  # noqa: F401
+from .fixtures import anyio_backend, mocked_responses  # noqa: F401

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,15 +1,19 @@
 """Pytest fixtures."""
 
 import pytest
-import responses
 
 from obc.providers.obf import OBFAPIClient
 
 
 @pytest.fixture
-def mocked_responses():
+def anyio_backend():
+    """Select asyncio backend for pytest anyio."""
+    return "asyncio"
+
+
+@pytest.fixture
+def mocked_responses(httpx_mock):
     """Use the responses module to mock Open Badge provider API responses."""
-    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
-        yield rsps
+    yield httpx_mock
     # pylint: disable=protected-access
     OBFAPIClient._access_token.cache_clear()

--- a/tests/providers/test_obf.py
+++ b/tests/providers/test_obf.py
@@ -2,10 +2,12 @@
 
 import logging
 import re
+from datetime import datetime
+from json import JSONDecodeError
 
+import httpx
 import pytest
 import requests
-import responses
 from pydantic import ValidationError
 
 from obc.exceptions import AuthenticationError, BadgeProviderError
@@ -26,12 +28,13 @@ from obc.providers.obf import (
 def test_client_init(mocked_responses):
     """Test the OBF client class instantiation."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     client_id = "real_client"
     client_secret = "super_duper"
@@ -39,7 +42,6 @@ def test_client_init(mocked_responses):
     assert api_client.api_root_url == "https://openbadgefactory.com"
     assert api_client.client_id == client_id
     assert api_client.client_secret == client_secret
-    assert api_client.raise_for_status is False
     assert "Content-Type" in api_client.headers
     assert api_client.headers["Content-Type"] == "application/json"
     assert isinstance(api_client.auth, OAuth2AccessToken) is True
@@ -48,18 +50,20 @@ def test_client_init(mocked_responses):
     api_client = OBFAPIClient(
         client_id=client_id, client_secret=client_secret, raise_for_status=True
     )
-    assert api_client.raise_for_status is True
+    assert api_client.event_hooks.get("response", None)
 
 
-def test_client_access_token(mocked_responses):
+@pytest.mark.anyio
+async def test_client_access_token(mocked_responses):
     """Test the OBF Client access_token private method."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     api_client = OBFAPIClient(client_id="real_client", client_secret="super_duper")
     # pylint: disable=protected-access
@@ -73,14 +77,15 @@ def test_client_access_token(mocked_responses):
         == "accesstoken123"
     )
     # Ensure _access_token property has been cached
-    assert len(mocked_responses.calls) == 1
+    assert len(mocked_responses.get_requests()) == 1
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "Error": "invalid credentials",
         },
-        status=403,
+        status_code=403,
     )
     with pytest.raises(
         AuthenticationError,
@@ -94,10 +99,11 @@ def test_client_access_token(mocked_responses):
             client_secret="fake_secret",
         )
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
-        body="invalid credentials",
-        status=403,
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
+        text="invalid credentials",
+        status_code=403,
     )
     with pytest.raises(
         AuthenticationError,
@@ -109,101 +115,118 @@ def test_client_access_token(mocked_responses):
         )
 
 
-def test_client_request(mocked_responses):
+@pytest.mark.anyio
+async def test_client_request(mocked_responses):
     """Test the OBF client request method."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     api_client = OBFAPIClient(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.get("https://openbadgefactory.com/v1/foo")
-    response = api_client.get("/foo")
+    mocked_responses.add_response(
+        method="GET", url="https://openbadgefactory.com/v1/foo"
+    )
+    response = await api_client.get("/foo")
     assert response.request.url == "https://openbadgefactory.com/v1/foo"
     assert response.status_code == 200
 
 
-def test_client_request_raise_for_status(mocked_responses):
+@pytest.mark.anyio
+async def test_client_request_raise_for_status(mocked_responses):
     """Test the OBF client request method when the response status is not ok."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     api_client = OBFAPIClient(
         client_id="real_client", client_secret="super_duper", raise_for_status=True
     )
 
-    mocked_responses.get("https://openbadgefactory.com/v1/foo", status=404)
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/foo",
+        status_code=404,
+    )
     with pytest.raises(
-        requests.HTTPError,
+        httpx.HTTPStatusError,
         match=(
-            "404 Client Error: Not Found for url: "
-            "https://openbadgefactory.com/v1/foo"
+            (
+                r"Client error '404 Not Found' "
+                r"for url 'https://openbadgefactory.com/v1/foo'.*"
+            )
         ),
     ):
-        api_client.get("/foo")
+        await api_client.get("/foo")
 
 
-def test_client_request_access_token_regeneration(mocked_responses):
+@pytest.mark.anyio
+async def test_client_request_access_token_regeneration(mocked_responses):
     """Test the OBF client request method when access token expired."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     api_client = OBFAPIClient(client_id="real_client", client_secret="super_duper")
     assert api_client.auth.access_token == "accesstoken123"
 
-    mocked_responses.add(
-        responses.GET, "https://openbadgefactory.com/v1/foo", status=403
+    mocked_responses.add_response(
+        method="GET", url="https://openbadgefactory.com/v1/foo", status_code=403
     )
-    mocked_responses.add(
-        responses.POST,
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken456",
         },
-        status=200,
+        status_code=200,
     )
-    mocked_responses.add(
-        responses.GET, "https://openbadgefactory.com/v1/foo", status=200
+    mocked_responses.add_response(
+        method="GET", url="https://openbadgefactory.com/v1/foo", status_code=200
     )
-    response = api_client.get("/foo")
+    response = await api_client.get("/foo")
     assert response.request.url == "https://openbadgefactory.com/v1/foo"
     assert response.status_code == 200
     assert api_client.auth.access_token == "accesstoken456"
 
 
-def test_client_check_auth(mocked_responses):
+@pytest.mark.anyio
+async def test_client_check_auth(mocked_responses):
     """Test the OBF client check_auth method."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     client_id = "real_client"
     api_client = OBFAPIClient(client_id=client_id, client_secret="super_duper")
 
-    mocked_responses.get(
-        f"https://openbadgefactory.com/v1/ping/{client_id}",
-        status=200,
-        body=f"{client_id}",
+    mocked_responses.add_response(
+        method="GET",
+        url=f"https://openbadgefactory.com/v1/ping/{client_id}",
+        status_code=200,
+        text=f"{client_id}",
     )
-    response = api_client.check_auth()
+    response = await api_client.check_auth()
     assert response.status_code == 200
     assert response.text == "real_client"
 
@@ -211,15 +234,17 @@ def test_client_check_auth(mocked_responses):
         AuthenticationError,
         match="Invalid access token for OBF",
     ):
-        mocked_responses.get(
-            f"https://openbadgefactory.com/v1/ping/{client_id}",
-            status=403,
+        mocked_responses.add_response(
+            method="GET",
+            url=f"https://openbadgefactory.com/v1/ping/{client_id}",
+            status_code=403,
         )
-        api_client.check_auth()
+        await api_client.check_auth()
 
 
 # pylint: disable=protected-access
-def test_iter_json():
+@pytest.mark.anyio
+async def test_iter_json():
     """Test the OBF provider iter_json method."""
 
     response = requests.Response()
@@ -240,7 +265,7 @@ def test_iter_json():
 
     response = requests.Response()
     response._content = b'{"id": "1"}\n{"id": "2"}\n{"id": "3"}\n'
-    with pytest.raises(requests.JSONDecodeError):
+    with pytest.raises(JSONDecodeError):
         response.json()
     assert list(OBFAPIClient.iter_json(response)) == [
         {"id": "1"},
@@ -253,7 +278,8 @@ def test_iter_json():
     assert list(OBFAPIClient.iter_json(response)) == [{"id": "1"}, {"id": "3"}]
 
 
-def test_badge_query_params():
+@pytest.mark.anyio
+async def test_badge_query_params():
     """Test the BadgeQuery model params method."""
 
     query = BadgeQuery(category=["one", "two"])
@@ -269,7 +295,8 @@ def test_badge_query_params():
     assert params.get("meta") is None
 
 
-def test_badge_check_id():
+@pytest.mark.anyio
+async def test_badge_check_id():
     """Test the Badge check_id method."""
 
     items = {
@@ -285,7 +312,8 @@ def test_badge_check_id():
         Badge(**items)
 
 
-def test_badgeissue_check_ids():
+@pytest.mark.anyio
+async def test_badgeissue_check_ids():
     """Test the BadgeIssue check_ids method."""
 
     items = {
@@ -313,84 +341,90 @@ def test_badgeissue_check_ids():
         BadgeIssue(**items)
 
 
-def test_provider_init(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_init(mocked_responses):
     """Test the OBF class instantiation."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
     assert isinstance(obf.api_client, OBFAPIClient)
     assert obf.api_client.client_id == "real_client"
     assert obf.api_client.client_secret == "super_duper"
-    assert obf.api_client.raise_for_status is False
 
 
-def test_provider_raise_for_status(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_raise_for_status(mocked_responses):
     """Test that the provider raises an exception on HTTP request error."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(
         client_id="real_client", client_secret="super_duper", raise_for_status=True
     )
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/badge/real_client",
-        status=404,
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/badge/real_client",
+        status_code=404,
     )
     with pytest.raises(
-        requests.HTTPError,
+        httpx.HTTPStatusError,
         match=(
-            "404 Client Error: Not Found for url: "
-            "https://openbadgefactory.com/v1/badge/real_client"
+            r"Client error '404 Not Found' for url "
+            r"'https://openbadgefactory.com/v1/badge/real_client'.*"
         ),
     ):
-        next(obf.badges.read())
+        await anext(obf.badges.read())
 
 
-def test_provider_badge_read_all(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_badge_read_all(mocked_responses):
     """Test the OBF read method without argument."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/badge/real_client",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/badge/real_client",
         json=[],
-        status=200,
+        status_code=200,
     )
-    assert len(list(obf.badges.read())) == 0
+    result = [badge async for badge in obf.badges.read()]
+    assert len(result) == 0
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/badge/real_client",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/badge/real_client",
         json=[
             {"id": "1", "name": "foo", "description": "lorem ipsum"},
             {"id": "2", "name": "bar", "description": "lorem ipsum"},
             {"id": "3", "name": "lol", "description": "lorem ipsum"},
         ],
-        status=200,
+        status_code=200,
     )
-    badges = list(obf.badges.read())
+    badges = [badge async for badge in obf.badges.read()]
     for badge in badges:
         assert isinstance(badge, Badge)
     assert badges[0].id == "1"
@@ -404,21 +438,23 @@ def test_provider_badge_read_all(mocked_responses):
     assert badges[2].description == "lorem ipsum"
 
 
-def test_provider_badge_read_one(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_badge_read_one(mocked_responses):
     """Test the OBF read method with a given badge argument."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/badge/real_client/1",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/badge/real_client/1",
         json=[
             {
                 "id": "1",
@@ -427,10 +463,10 @@ def test_provider_badge_read_one(mocked_responses):
                 "metadata": {"life": 42},
             }
         ],
-        status=200,
+        status_code=200,
     )
     target_badge = Badge(id="1", name="foo", description="lorem ipsum")
-    badge = next(obf.badges.read(badge=target_badge))
+    badge = await anext(obf.badges.read(badge=target_badge))
     assert badge.id == "1"
     assert "life" in badge.metadata
     assert badge.metadata.get("life") == 42
@@ -440,92 +476,102 @@ def test_provider_badge_read_one(mocked_responses):
         BadgeProviderError,
         match="the ID field is required",
     ):
-        next(obf.badges.read(badge=target_badge))
+        await anext(obf.badges.read(badge=target_badge))
 
 
-def test_provider_badge_read_selected(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_badge_read_selected(mocked_responses):
     """Test the OBF read method with a badge query."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/badge/real_client",
+    mocked_responses.add_response(
+        method="GET",
+        url=re.compile(r"https://openbadgefactory.com/v1/badge/real_client.*"),
         json=[],
-        status=200,
+        status_code=200,
     )
     query = BadgeQuery(draft=0)
-    assert len(list(obf.badges.read(query=query))) == 0
+    badges = [badge async for badge in obf.badges.read(query=query)]
+    assert len(badges) == 0
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/badge/real_client",
+    mocked_responses.add_response(
+        method="GET",
+        url=re.compile(r"https://openbadgefactory.com/v1/badge/real_client.*"),
         json=[
             {"id": "1", "name": "foo", "description": "lorem ipsum"},
             {"id": "2", "name": "bar", "description": "lorem ipsum"},
             {"id": "3", "name": "lol", "description": "lorem ipsum"},
         ],
-        status=200,
+        status_code=200,
     )
     query = BadgeQuery(query="lorem ipsum")
-    assert len(list(obf.badges.read(query=query))) == 3
+    badges = [badge async for badge in obf.badges.read(query=query)]
+    assert len(badges) == 3
 
 
-def test_provider_badge_read_with_validationerror(mocked_responses, caplog):
+@pytest.mark.anyio
+async def test_provider_badge_read_with_validationerror(mocked_responses, caplog):
     """Test the OBF read method with a validation error."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/badge/real_client",
+    mocked_responses.add_response(
+        method="GET",
+        url=re.compile(r"https://openbadgefactory.com/v1/badge/real_client.*"),
         json=[],
-        status=200,
+        status_code=200,
     )
     query = BadgeQuery(draft=0)
-    assert len(list(obf.badges.read(query=query))) == 0
+    badges = [badge async for badge in obf.badges.read(query=query)]
+    assert len(badges) == 0
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/badge/real_client",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/badge/real_client",
         json=[
             {"id": "1", "name": 1, "description": "lorem ipsum"},
             {"id": "2", "name": "bar", "description": "lorem ipsum"},
         ],
-        status=200,
+        status_code=200,
     )
 
     with caplog.at_level(logging.WARNING):
-        assert len(list(obf.badges.read())) == 1
+        badges = [badge async for badge in obf.badges.read()]
+        assert len(badges) == 1
 
     assert ("obc.providers.obf", logging.WARNING) in [
         (class_, level) for (class_, level, _) in caplog.record_tuples
     ]
 
 
-def test_provider_badge_create(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_badge_create(mocked_responses):
     """Test the OBF create method with a given badge argument."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
@@ -533,150 +579,158 @@ def test_provider_badge_create(mocked_responses):
     mocked = submitted.model_copy()
     mocked.id = "abcd1234"
     del mocked.is_created
-    mocked_responses.add(
-        responses.POST,
-        "https://openbadgefactory.com/v1/badge/real_client",
-        status=201,
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/badge/real_client",
+        status_code=201,
         headers={"Location": "/v1/badge/real_client/abcd1234"},
     )
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/badge/real_client/abcd1234",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/badge/real_client/abcd1234",
         json=mocked.model_dump(),
-        status=200,
+        status_code=200,
     )
-    created = obf.badges.create(badge=submitted)
+    created = await obf.badges.create(badge=submitted)
 
     assert created.name == "foo"
     assert created.description == "lorem ipsum"
     assert created.id == "abcd1234"
 
     # An error occurred while creating the badge
-    mocked_responses.add(
-        responses.POST,
-        "https://openbadgefactory.com/v1/badge/real_client",
-        status=500,
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/badge/real_client",
+        status_code=500,
     )
     with pytest.raises(BadgeProviderError, match="Cannot create badge"):
-        obf.badges.create(badge=submitted)
+        await obf.badges.create(badge=submitted)
 
 
-def test_provider_badge_update(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_badge_update(mocked_responses):
     """Test the OBF update method with a given badge argument."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
     with pytest.raises(
         BadgeProviderError, match="We expect an existing badge instance"
     ):
-        obf.badges.update(Badge(name="foo", description="lorem ipsum"))
+        await obf.badges.update(Badge(name="foo", description="lorem ipsum"))
 
     badge = Badge(id="abcd1234", name="foo", description="lorem ipsum")
-    mocked_responses.add(
-        responses.PUT,
-        "https://openbadgefactory.com/v1/badge/real_client/abcd1234",
-        status=204,
+    mocked_responses.add_response(
+        method="PUT",
+        url="https://openbadgefactory.com/v1/badge/real_client/abcd1234",
+        status_code=204,
     )
-    updated = obf.badges.update(badge)
+    updated = await obf.badges.update(badge)
     assert updated == badge
 
     # An error occurred while updating the badge
-    mocked_responses.add(
-        responses.PUT,
-        "https://openbadgefactory.com/v1/badge/real_client/abcd1234",
-        status=500,
+    mocked_responses.add_response(
+        method="PUT",
+        url="https://openbadgefactory.com/v1/badge/real_client/abcd1234",
+        status_code=500,
     )
     with pytest.raises(
         BadgeProviderError, match="Cannot update badge with ID: abcd1234"
     ):
-        obf.badges.update(badge=badge)
+        await obf.badges.update(badge=badge)
 
 
-def test_provider_badge_delete_one(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_badge_delete_one(mocked_responses):
     """Test the OBF delete method with a given badge argument."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
     with pytest.raises(
         BadgeProviderError, match="We expect an existing badge instance"
     ):
-        obf.badges.delete(Badge(name="foo", description="lorem ipsum"))
+        await obf.badges.delete(Badge(name="foo", description="lorem ipsum"))
 
     badge = Badge(id="abcd1234", name="foo", description="lorem ipsum")
-    mocked_responses.add(
-        responses.DELETE,
-        "https://openbadgefactory.com/v1/badge/real_client/abcd1234",
-        status=204,
+    mocked_responses.add_response(
+        method="DELETE",
+        url="https://openbadgefactory.com/v1/badge/real_client/abcd1234",
+        status_code=204,
     )
-    assert obf.badges.delete(badge) is None
+    assert await obf.badges.delete(badge) is None
 
     # An error occurred while deleting the badge
-    mocked_responses.add(
-        responses.DELETE,
-        "https://openbadgefactory.com/v1/badge/real_client/abcd1234",
-        status=500,
+    mocked_responses.add_response(
+        method="DELETE",
+        url="https://openbadgefactory.com/v1/badge/real_client/abcd1234",
+        status_code=500,
     )
     with pytest.raises(
         BadgeProviderError, match="Cannot delete badge with ID: abcd1234"
     ):
-        obf.badges.delete(badge=badge)
+        await obf.badges.delete(badge=badge)
 
 
-def test_provider_badge_delete_all(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_badge_delete_all(mocked_responses):
     """Test the OBF delete method without badge argument (delete all badges)."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.DELETE,
-        "https://openbadgefactory.com/v1/badge/real_client",
-        status=204,
+    mocked_responses.add_response(
+        method="DELETE",
+        url="https://openbadgefactory.com/v1/badge/real_client",
+        status_code=204,
     )
-    assert obf.badges.delete() is None
+    assert await obf.badges.delete() is None
 
     # An error occurred while updating the badge
-    mocked_responses.add(
-        responses.DELETE,
-        "https://openbadgefactory.com/v1/badge/real_client",
-        status=500,
+    mocked_responses.add_response(
+        method="DELETE",
+        url="https://openbadgefactory.com/v1/badge/real_client",
+        status_code=500,
     )
     with pytest.raises(
         BadgeProviderError,
         match="Cannot delete badges for client with ID: real_client",
     ):
-        obf.badges.delete()
+        await obf.badges.delete()
 
 
-def test_provider_badge_issue_non_existing(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_badge_issue_non_existing(mocked_responses):
     """Trying to issue a badge for a non-existing instance should fail."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
@@ -690,18 +744,20 @@ def test_provider_badge_issue_non_existing(mocked_responses):
         BadgeProviderError,
         match="We expect an existing badge instance",
     ):
-        obf.badges.issue(badge, issue)
+        await obf.badges.issue(badge, issue)
 
 
-def test_provider_badge_issue_draft(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_badge_issue_draft(mocked_responses):
     """Trying to issue a badge for a draft instance should fail."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
@@ -715,18 +771,20 @@ def test_provider_badge_issue_draft(mocked_responses):
         BadgeProviderError,
         match="You cannot issue a badge with a draft status",
     ):
-        obf.badges.issue(badge, issue)
+        await obf.badges.issue(badge, issue)
 
 
-def test_provider_badge_issue_success(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_badge_issue_success(mocked_responses):
     """Test the OBF issue method."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
@@ -741,61 +799,61 @@ def test_provider_badge_issue_success(mocked_responses):
     mocked.id = "issueId1234"
     mocked.badge_id = "badgeId1234"
     del mocked.is_created
-    mocked_responses.add(
-        responses.POST,
-        "https://openbadgefactory.com/v1/badge/real_client/badgeId1234",
-        status=201,
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/badge/real_client/badgeId1234",
+        status_code=201,
         headers={"Location": "/v1/event/real_client/issueId1234"},
     )
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/event/real_client/issueId1234",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/event/real_client/issueId1234",
         json=mocked.model_dump(),
-        status=200,
+        status_code=200,
     )
-    created_issue = obf.badges.issue(badge, submitted_issue)
+    created_issue = await obf.badges.issue(badge, submitted_issue)
     assert created_issue.email_subject == submitted_issue.email_subject
     assert created_issue.badge_id == badge.id
     assert not created_issue.revoked
     assert created_issue.is_created
     assert created_issue.id == "issueId1234"
 
-    mocked_responses.add(
-        responses.POST,
-        "https://openbadgefactory.com/v1/badge/real_client/badgeId1234",
-        status=500,
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/badge/real_client/badgeId1234",
+        status_code=500,
     )
     with pytest.raises(
         BadgeProviderError,
         match="Cannot issue badge with ID: badgeId1234",
     ):
-        obf.badges.issue(badge, submitted_issue)
+        await obf.badges.issue(badge, submitted_issue)
 
 
-def test_provider_badge_revoke(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_badge_revoke(mocked_responses):
     """Test the OBF revoke method."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.DELETE,
-        "https://openbadgefactory.com/v1/event/real_client/foo_event",
-        status=204,
-        match=[
-            responses.matchers.query_string_matcher(
-                "email=foo@example.org|bar@example.org"
-            )
-        ],
+    mocked_responses.add_response(
+        method="DELETE",
+        url=(
+            "https://openbadgefactory.com/v1/event/real_client/foo_event"
+            "?email=foo@example.org|bar@example.org"
+        ),
+        status_code=204,
     )
     assert (
-        obf.badges.revoke(
+        await obf.badges.revoke(
             BadgeRevokation(
                 event_id="foo_event",
                 recipient=["foo@example.org", "bar@example.org"],
@@ -805,10 +863,12 @@ def test_provider_badge_revoke(mocked_responses):
     )
 
     # An error occurred while updating the badge
-    mocked_responses.add(
-        responses.DELETE,
-        "https://openbadgefactory.com/v1/event/real_client/foo_event",
-        status=500,
+    mocked_responses.add_response(
+        method="DELETE",
+        url=re.compile(
+            r"https://openbadgefactory.com/v1/event/real_client/foo_event.*"
+        ),
+        status_code=500,
     )
     with pytest.raises(
         BadgeProviderError,
@@ -819,7 +879,7 @@ def test_provider_badge_revoke(mocked_responses):
             )
         ),
     ):
-        obf.badges.revoke(
+        await obf.badges.revoke(
             BadgeRevokation(
                 event_id="foo_event",
                 recipient=[
@@ -829,29 +889,32 @@ def test_provider_badge_revoke(mocked_responses):
         )
 
 
-def test_provider_event_read_all(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_event_read_all(mocked_responses):
     """Test the OBF event read method without argument."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/event/real_client",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/event/real_client",
         json=[],
-        status=200,
+        status_code=200,
     )
-    assert len(list(obf.events.read())) == 0
+    events = [event async for event in obf.events.read()]
+    assert len(events) == 0
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/event/real_client",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/event/real_client",
         json=[
             {
                 "id": "1",
@@ -872,9 +935,9 @@ def test_provider_event_read_all(mocked_responses):
                 "log_entry": {"issuer": "anonymous"},
             },
         ],
-        status=200,
+        status_code=200,
     )
-    issues = list(obf.events.read())
+    issues = [event async for event in obf.events.read()]
     for issue in issues:
         assert isinstance(issue, BadgeIssue)
     assert issues[0].id == "1"
@@ -895,21 +958,23 @@ def test_provider_event_read_all(mocked_responses):
     assert issues[1].is_created
 
 
-def test_provider_event_read_one(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_event_read_one(mocked_responses):
     """Test the OBF event read method with a given issue argument."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/event/real_client/1",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/event/real_client/1",
         json={
             "id": "1",
             "badge_id": "1234",
@@ -919,10 +984,10 @@ def test_provider_event_read_one(mocked_responses):
             "revoked": {},
             "log_entry": {"issuer": "luc"},
         },
-        status=200,
+        status_code=200,
     )
     target_issue = BadgeIssue(id="1", recipient=["foo@bar.com"])
-    issue = next(obf.events.read(issue=target_issue))
+    issue = await anext(obf.events.read(issue=target_issue))
     assert issue == BadgeIssue(
         id="1",
         badge_id="1234",
@@ -939,33 +1004,72 @@ def test_provider_event_read_one(mocked_responses):
         BadgeProviderError,
         match="the ID field is required",
     ):
-        next(obf.events.read(issue=target_issue))
+        await anext(obf.events.read(issue=target_issue))
 
 
-def test_provider_event_read_selected(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_event_read_selected(mocked_responses):
     """Test the OBF event read method with a issue query."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/event/real_client",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/event/real_client",
         json=[],
-        status=200,
+        status_code=200,
     )
     query = IssueQuery()
-    assert len(list(obf.events.read(query=query))) == 0
+    events = [event async for event in obf.events.read(query=query)]
+    assert len(events) == 0
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/event/real_client",
+    mocked_responses.add_response(
+        method="GET",
+        url=(
+            "https://openbadgefactory.com/v1/event/real_client"
+            "?begin=1670821200&end=1670864400"
+        ),
+        json=[
+            {
+                "id": "1",
+                "badge_id": "1234",
+                "recipient": ["foo@bar.com", "bar@foo.com"],
+                "expires": 1670821201,
+                "issued_on": 1670821200,
+                "revoked": {},
+                "log_entry": {"issuer": "luc"},
+            },
+            {
+                "id": "2",
+                "badge_id": "1234",
+                "recipient": ["toto@bar.com", "tata@foo.com"],
+                "expires": 1670822201,
+                "issued_on": 1670822200,
+                "revoked": {},
+                "log_entry": {"issuer": "toto"},
+            },
+        ],
+        status_code=200,
+    )
+
+    query = IssueQuery(
+        begin=datetime(2022, 12, 12, 5, 0, 0),
+        end=datetime(2022, 12, 12, 17, 0, 0),
+    )
+    events = [event async for event in obf.events.read(query=query)]
+    assert len(events) == 2
+
+    mocked_responses.add_response(
+        method="GET",
+        url=re.compile(r"https://openbadgefactory.com/v1/event/real_client.*"),
         json=[
             {
                 "id": "1",
@@ -989,33 +1093,36 @@ def test_provider_event_read_selected(mocked_responses):
                 "id": "3",
                 "badge_id": "2345",
                 "recipient": ["toto@bar.com", "tata@foo.com"],
-                "expires": 1670832085,
-                "issued_on": 1670822084,
+                "expires": 1670922085,
+                "issued_on": 1670922084,
                 "revoked": {},
                 "log_entry": {"issuer": "tata"},
             },
         ],
-        status=200,
+        status_code=200,
     )
     query = IssueQuery(recipient=["toto@bar.com", "tata@foo.com"])
-    assert len(list(obf.events.read(query=query))) == 3
+    events = [event async for event in obf.events.read(query=query)]
+    assert len(events) == 3
 
 
-def test_provider_event_read_with_validationerror(mocked_responses, caplog):
+@pytest.mark.anyio
+async def test_provider_event_read_with_validationerror(mocked_responses, caplog):
     """Test the OBF event read method with a validation error."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/event/real_client",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/event/real_client",
         json=[
             {
                 "id": "1",
@@ -1036,31 +1143,34 @@ def test_provider_event_read_with_validationerror(mocked_responses, caplog):
                 "log_entry": {"issuer": "toto"},
             },
         ],
-        status=200,
+        status_code=200,
     )
     with caplog.at_level(logging.WARNING):
-        assert len(list(obf.events.read())) == 1
+        events = [event async for event in obf.events.read()]
+        assert len(events) == 1
 
     assert ("obc.providers.obf", logging.WARNING) in [
         (class_, level) for (class_, level, _) in caplog.record_tuples
     ]
 
 
-def test_provider_assertion_read_all(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_assertion_read_all(mocked_responses):
     """Test the OBF assertion read method without argument."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/event/real_client/1/assertion",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/event/real_client/1/assertion",
         json=[
             {
                 "id": "1234",
@@ -1082,10 +1192,12 @@ def test_provider_assertion_read_all(mocked_responses):
                 "status": "accepted",
             },
         ],
-        status=200,
+        status_code=200,
     )
     assertion = BadgeAssertion(event_id="1")
-    assertions = list(obf.assertions.read(assertion=assertion))
+    assertions = [
+        assertion async for assertion in obf.assertions.read(assertion=assertion)
+    ]
     for assertion in assertions:
         assert isinstance(assertion, BadgeAssertion)
     assert assertions[0].id == "1234"
@@ -1105,21 +1217,25 @@ def test_provider_assertion_read_all(mocked_responses):
     assert assertions[1].status == "accepted"
 
 
-def test_provider_assertion_read_selected(mocked_responses):
+@pytest.mark.anyio
+async def test_provider_assertion_read_selected(mocked_responses):
     """Test the OBF event assertion read method with an assertion query."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/event/real_client/4321/assertion",
+    mocked_responses.add_response(
+        method="GET",
+        url=re.compile(
+            r"https://openbadgefactory.com/v1/event/real_client/4321/assertion.*"
+        ),
         json=[
             {
                 "id": "1234",
@@ -1141,28 +1257,34 @@ def test_provider_assertion_read_selected(mocked_responses):
                 "status": "accepted",
             },
         ],
-        status=200,
+        status_code=200,
     )
     assertion = BadgeAssertion(event_id="4321")
     query = AssertionQuery(email=["foo@bar.com"])
-    assert len(list(obf.assertions.read(assertion=assertion, query=query))) == 2
+    assertions = [
+        assertion
+        async for assertion in obf.assertions.read(assertion=assertion, query=query)
+    ]
+    assert len(assertions) == 2
 
 
-def test_provider_assertion_read_with_validationerror(mocked_responses, caplog):
+@pytest.mark.anyio
+async def test_provider_assertion_read_with_validationerror(mocked_responses, caplog):
     """Test the OBF event assertion read method with a validation error."""
 
-    mocked_responses.post(
-        "https://openbadgefactory.com/v1/client/oauth2/token",
+    mocked_responses.add_response(
+        method="POST",
+        url="https://openbadgefactory.com/v1/client/oauth2/token",
         json={
             "access_token": "accesstoken123",
         },
-        status=200,
+        status_code=200,
     )
     obf = OBF(client_id="real_client", client_secret="super_duper")
 
-    mocked_responses.add(
-        responses.GET,
-        "https://openbadgefactory.com/v1/event/real_client/4321/assertion",
+    mocked_responses.add_response(
+        method="GET",
+        url="https://openbadgefactory.com/v1/event/real_client/4321/assertion",
         json=[
             {
                 "id": "1234",
@@ -1181,12 +1303,15 @@ def test_provider_assertion_read_with_validationerror(mocked_responses, caplog):
                 "status": None,
             },
         ],
-        status=200,
+        status_code=200,
     )
 
     assertion = BadgeAssertion(event_id="4321")
     with caplog.at_level(logging.WARNING):
-        assert len(list(obf.assertions.read(assertion=assertion))) == 1
+        assertions = [
+            assertion async for assertion in obf.assertions.read(assertion=assertion)
+        ]
+        assert len(assertions) == 1
 
     assert ("obc.providers.obf", logging.WARNING) in [
         (class_, level) for (class_, level, _) in caplog.record_tuples
@@ -1197,4 +1322,4 @@ def test_provider_assertion_read_with_validationerror(mocked_responses, caplog):
         BadgeProviderError,
         match="We expect an existing issue",
     ):
-        list(obf.assertions.read(assertion=assertion))
+        await anext(obf.assertions.read(assertion=assertion))


### PR DESCRIPTION
## Purpose

When using obc, we could need to fetch a lot of assertions thus making a large  
number of requests without being able to make them concurrently.                

## Proposal

Switching from `requests` to `httpx` would allow us to make OBF methods         
asynchronous.

- [x] Switch OBF provider to use `httpx` instead of `requests`
- [x] Adapt tests

