### PR TITLE
🐛(obf) fix types accepted for BadgeIssue fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - OBF: raise a `BadgeProviderError` if `read` methods cannot yield objects
+- OBF: `BadgeIssue` params `badge_override` and `log_entry` now accept strings
 
 ## [1.0.0] - 2023-09-06
 

--- a/src/obc/providers/obf.py
+++ b/src/obc/providers/obf.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from datetime import datetime
 from functools import cache
 from json import JSONDecodeError
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 from urllib.parse import urljoin
 
 import httpx
@@ -16,6 +16,7 @@ from pydantic import (
     EmailStr,
     Field,
     HttpUrl,
+    Json,
     ValidationError,
     field_serializer,
     model_validator,
@@ -249,8 +250,8 @@ class BadgeIssue(BaseModel):
     email_body: Optional[str] = None
     email_link_text: Optional[str] = None
     email_footer: Optional[str] = None
-    badge_override: Optional[IssueBadgeOverride] = None
-    log_entry: Optional[dict] = None
+    badge_override: Optional[IssueBadgeOverride | Json[IssueBadgeOverride]] = None
+    log_entry: Optional[dict | Json[Any]] = None
     send_email: Literal[0, 1] = 1
     badge_id: Optional[str] = None
     revoked: Optional[dict] = None

--- a/tests/providers/test_obf.py
+++ b/tests/providers/test_obf.py
@@ -19,6 +19,7 @@ from obc.providers.obf import (
     BadgeIssue,
     BadgeQuery,
     BadgeRevokation,
+    IssueBadgeOverride,
     IssueQuery,
     OAuth2AccessToken,
     OBFAPIClient,
@@ -339,6 +340,33 @@ async def test_badgeissue_check_ids():
         match="Badge issues should have both an `id` and `badge_id` field.",
     ):
         BadgeIssue(**items)
+
+
+@pytest.mark.anyio
+async def test_badgeissue_json_types():
+    """Test the BadgeIssue deserializer methods."""
+
+    items = {
+        "recipient": ["toto@bar.com"],
+        "is_created": True,
+        "id": "id1234",
+        "badge_id": "1234",
+        "badge_override": '{"name": "toto", "description": "Lorem Ipsum"}',
+    }
+
+    assert BadgeIssue(**items).badge_override == IssueBadgeOverride(
+        name="toto",
+        description="Lorem Ipsum",
+    )
+
+    items = {
+        "recipient": ["toto@bar.com"],
+        "id": "id1234",
+        "badge_id": "1234",
+        "log_entry": '{"test": "OK"}',
+    }
+
+    assert BadgeIssue(**items).log_entry == {"test": "OK"}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
`BadgeIssue` pydantic model has several issues with field types:
- `badge_override` was only accepting instances of `IssueBadgeOverride`, and
could not parse the output of an OBF issue request.
- `log_entry` was only accepting dict inputs, and could not parse the output
of an OBF issue request.

Both now also accept string inputs, and a field validator tries to convert them
to their complex types.


