### PR TITLE
✏️(project) fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - OBF: raise a `BadgeProviderError` if `read` methods cannot yield objects
 - OBF: `BadgeIssue` params `badge_override` and `log_entry` now accept strings
+- OBF: `BadgeRevokation` is replaced by `BadgeRevocation`
 
 ## [1.0.0] - 2023-09-06
 

--- a/src/obc/providers/base.py
+++ b/src/obc/providers/base.py
@@ -43,7 +43,7 @@ class BaseBadge(ABC):
         """Issue a badge."""
 
     @abstractmethod
-    async def revoke(self, revokation):
+    async def revoke(self, revocation):
         """Revoke one or more badges."""
 
 

--- a/src/obc/providers/obf.py
+++ b/src/obc/providers/obf.py
@@ -344,8 +344,8 @@ class AssertionQuery(BaseModel):
         return query
 
 
-class BadgeRevokation(BaseModel):
-    """Open Badge Factory badge revokation model."""
+class BadgeRevocation(BaseModel):
+    """Open Badge Factory badge revocation model."""
 
     event_id: str
     recipient: list[EmailStr]
@@ -492,7 +492,7 @@ class OBFBadge(BaseBadge):
             response = await self.api_client.get(
                 f"/badge/{self.api_client.client_id}/{badge.id}"
             )
-            logger.info("Successfully get badge with ID: %s", badge.id)
+            logger.info("Successfully got badge with ID: %s", badge.id)
 
         # Get a selected badge list
         elif query is not None:
@@ -608,16 +608,16 @@ class OBFBadge(BaseBadge):
         # Return BadgeIssue with added fields
         return badge.model_copy(update=fetched.model_dump())
 
-    async def revoke(self, revokation: BadgeRevokation) -> None:
+    async def revoke(self, revocation: BadgeRevocation) -> None:
         """Revoke one or more issued badges."""
-        logger.warning("Will revoke event: %s", revokation)
+        logger.warning("Will revoke event: %s", revocation)
         response = await self.api_client.delete(
-            f"/event/{self.api_client.client_id}/{revokation.event_id}",
-            params=revokation.params(),
+            f"/event/{self.api_client.client_id}/{revocation.event_id}",
+            params=revocation.params(),
         )
         if not response.status_code == httpx.codes.NO_CONTENT:
-            raise BadgeProviderError(f"Cannot revoke event: {revokation}")
-        logger.info("Revoked event: %s", revokation)
+            raise BadgeProviderError(f"Cannot revoke event: {revocation}")
+        logger.info("Revoked event: %s", revocation)
 
 
 class OBF(BaseProvider):

--- a/tests/providers/test_obf.py
+++ b/tests/providers/test_obf.py
@@ -18,7 +18,7 @@ from obc.providers.obf import (
     BadgeAssertion,
     BadgeIssue,
     BadgeQuery,
-    BadgeRevokation,
+    BadgeRevocation,
     IssueBadgeOverride,
     IssueQuery,
     OAuth2AccessToken,
@@ -885,7 +885,7 @@ async def test_provider_badge_revoke(mocked_responses):
     )
     assert (
         await obf.badges.revoke(
-            BadgeRevokation(
+            BadgeRevocation(
                 event_id="foo_event",
                 recipient=["foo@example.org", "bar@example.org"],
             )
@@ -911,7 +911,7 @@ async def test_provider_badge_revoke(mocked_responses):
         ),
     ):
         await obf.badges.revoke(
-            BadgeRevokation(
+            BadgeRevocation(
                 event_id="foo_event",
                 recipient=[
                     "foo@example.org",


### PR DESCRIPTION
Fix typo "revokation". Replace by "revocation".

Partially fixes https://github.com/openfun/open-badges-client/issues/29