### PR TITLE
🔖(major) bump release to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0] - 2023-11-02
+
 ### Changed
 
 - OBF: `BadgeRevokation` is replaced by `BadgeRevocation` [BC]
@@ -48,7 +50,8 @@ IDs as input parameters when sufficient instead of whole objects [BC]
 
 - Extract the OBF badge provider from the Joanie project
 
-[Unreleased]: https://github.com/openfun/open-badges-client/compare/v1.0.0...main
+[Unreleased]: https://github.com/openfun/open-badges-client/compare/v2.0.0...main
+[2.0.0]: https://github.com/openfun/open-badges-client/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/openfun/open-badges-client/compare/v0.2.1...v1.0.0
 [0.2.1]: https://github.com/openfun/open-badges-client/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/openfun/open-badges-client/compare/v0.1.0...v0.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = obc
-version = 1.0.0
+version = 2.0.0
 description = The Open Badges Client
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/obc/__init__.py
+++ b/src/obc/__init__.py
@@ -1,3 +1,3 @@
 """OBC: the Open Badge Client."""
 
-__version__ = "1.0.0"
+__version__ = "2.0.0"


### PR DESCRIPTION
## Changed

- OBF: `BadgeRevokation` is replaced by `BadgeRevocation` [BC]
- OBF: modified `OBFBadge`, `OBFAssertion` and `OBFEvent` CRUD methods to take
IDs as input parameters when sufficient instead of whole objects [BC]
- OBF: raise a `BadgeProviderError` if `read` methods cannot yield objects
- OBF: `BadgeIssue` params `badge_override` and `log_entry` now accept strings

