### PR TITLE
✨(project) improve CRUD methods for OBF provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- OBF: `BadgeRevokation` is replaced by `BadgeRevocation` [BC]
+- OBF: modified `OBFBadge`, `OBFAssertion` and `OBFEvent` CRUD methods to take
+IDs as input parameters when sufficient instead of whole objects [BC]
 - OBF: raise a `BadgeProviderError` if `read` methods cannot yield objects
 - OBF: `BadgeIssue` params `badge_override` and `log_entry` now accept strings
-- OBF: `BadgeRevokation` is replaced by `BadgeRevocation`
 
 ## [1.0.0] - 2023-09-06
 

--- a/src/obc/providers/base.py
+++ b/src/obc/providers/base.py
@@ -11,7 +11,7 @@ class BaseAssertion(ABC):
         """Initialize the assertion class."""
 
     @abstractmethod
-    async def read(self, assertion, query=None):
+    async def read(self, event_id, query=None):
         """Read an assertion."""
 
 
@@ -27,7 +27,7 @@ class BaseBadge(ABC):
         """Create a badge."""
 
     @abstractmethod
-    async def read(self, badge=None, query=None):
+    async def read(self, badge_id=None, query=None):
         """Read a badge."""
 
     @abstractmethod
@@ -35,11 +35,11 @@ class BaseBadge(ABC):
         """Update a badge."""
 
     @abstractmethod
-    async def delete(self, badge=None):
+    async def delete(self, badge_id=None):
         """Delete a badge."""
 
     @abstractmethod
-    async def issue(self, badge, issue):
+    async def issue(self, badge_id, issue):
         """Issue a badge."""
 
     @abstractmethod


### PR DESCRIPTION

## Purpose

CRUD methods were clunky to use by having to provide a instance of a Badge,
a BadgeIssue or an Assertion to read or delete.

## Proposal

Switching to using ids instead (badge_id, issue_id etc) when it's sufficient.

