### PR TITLE
🏷️(obf) allow non email strings for issuing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- OBF: Remove email validation of `BadgeIssue.recipient` field
+
 ## [2.0.0] - 2023-11-02
 
 ### Changed

--- a/src/obc/providers/obf.py
+++ b/src/obc/providers/obf.py
@@ -243,7 +243,7 @@ class BadgeIssue(BaseModel):
     """Open Badge Factory badge issue Model."""
 
     id: Optional[str] = None
-    recipient: list[EmailStr | str]
+    recipient: list[str]
     expires: Optional[int] = None
     issued_on: Optional[int] = None
     email_subject: Optional[str] = None


### PR DESCRIPTION
## Purpose

Having `EmailStr` as the first pydantic type of `recipient` was converting any
string containing an email (e.g. "Toto Martin < toto.martin@example.com >") to the
email only (i.e. "toto.martin@example.com").

## Proposal

Removing this type to allow every string, as OBF issuing allows to provide a
fullname alongside the email(e.g. "Toto Martin < toto.martins@example.com >".

